### PR TITLE
Erro ao clonar DMS/Filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ soa.log
 uploads/
 *sublime*
 composer.phar
+DMS/*

--- a/vendor.sh
+++ b/vendor.sh
@@ -3,7 +3,7 @@ mkdir vendor
 cd vendor
 wget http://silex.sensiolabs.org/get/silex.phar
 mkdir -p DMS/Filter
-git clone http://github.com/rdohms/DMS-Filter.git DMS/Filter
+git clone https://github.com/rdohms/dms-filter.git DMS/Filter
 mkdir doctrine
 git clone https://github.com/doctrine/common.git doctrine/common
 git clone https://github.com/doctrine/dbal.git doctrine/dbal


### PR DESCRIPTION
Bom estava querendo testar o SOA-Server e tive um erro na clonagem do DMS/Filter e percebi que o link não batia com o link do repositório original, então tomei a liberdade de alterar no vendor.sh o mesmo e estou enviando para vocês.
